### PR TITLE
Fix description

### DIFF
--- a/PodcastRewind/Services/FeedRewindInfoRepository.cs
+++ b/PodcastRewind/Services/FeedRewindInfoRepository.cs
@@ -58,15 +58,15 @@ public class FeedRewindInfoRepository(IConfiguration config, IMemoryCache cache)
 
     public async Task<FeedRewindInfo?> GetAsync(Guid id)
     {
-        if (cache.TryGetValue(id, out FeedRewindInfo? info)) return info;
-        info = await LoadFeedRewindInfoFromFileAsync(id);
-        if (info != null) cache.Set(id, info, CacheEntryOptions);
-        return info;
+        if (cache.TryGetValue(id, out FeedRewindInfo? feedRewind)) return feedRewind;
+        feedRewind = await LoadFeedRewindInfoFromFileAsync(id);
+        if (feedRewind != null) cache.Set(id, feedRewind, CacheEntryOptions);
+        return feedRewind;
     }
 
     private async Task SaveFeedRewindInfoToFileAsync(Guid id, FeedRewindInfo feedRewind)
     {
-        var filePath = Path.Combine(_dataFilesDirectory, string.Concat(id.ToString(), ".json"));
+        var filePath = Path.Combine(_dataFilesDirectory, $"{id}.json");
         Directory.CreateDirectory(_dataFilesDirectory);
         await using var stream = File.Create(filePath);
         await JsonSerializer.SerializeAsync(stream, feedRewind);
@@ -75,7 +75,7 @@ public class FeedRewindInfoRepository(IConfiguration config, IMemoryCache cache)
 
     private async Task<FeedRewindInfo?> LoadFeedRewindInfoFromFileAsync(Guid id)
     {
-        var filePath = Path.Combine(_dataFilesDirectory, string.Concat(id.ToString(), ".json"));
+        var filePath = Path.Combine(_dataFilesDirectory, $"{id}.json");
         try
         {
             await using var stream = File.OpenRead(filePath);

--- a/PodcastRewind/Services/SyndicationFeedService.cs
+++ b/PodcastRewind/Services/SyndicationFeedService.cs
@@ -13,13 +13,15 @@ public interface ISyndicationFeedService
 public class SyndicationFeedService(IHttpClientFactory httpClientFactory, IMemoryCache cache)
     : ISyndicationFeedService
 {
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetAbsoluteExpiration(TimeSpan.FromHours(20));
+
     public async Task<SyndicationFeed?> GetSyndicationFeedAsync(string url)
     {
         if (!Uri.IsWellFormedUriString(url, UriKind.Absolute)) return null;
         if (cache.TryGetValue(url, out SyndicationFeed? feed)) return feed;
         feed = await GetRemoteSyndicationFeedAsync(url);
-        if (feed != null)
-            cache.Set(url, feed, new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromHours(20)));
+        if (feed != null) cache.Set(url, feed, CacheEntryOptions);
         return feed;
     }
 

--- a/PodcastRewind/TestData/TestFeedRewindInfoRepository.cs
+++ b/PodcastRewind/TestData/TestFeedRewindInfoRepository.cs
@@ -1,16 +1,21 @@
+using Microsoft.Extensions.Caching.Memory;
 using PodcastRewind.Models.Dto;
 using PodcastRewind.Models.Entities;
 using PodcastRewind.Services;
 
 namespace PodcastRewind.TestData;
 
-public class TestFeedRewindInfoRepository : IFeedRewindInfoRepository
+public class TestFeedRewindInfoRepository(IMemoryCache cache) : IFeedRewindInfoRepository
 {
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetSlidingExpiration(TimeSpan.FromHours(3))
+        .SetAbsoluteExpiration(TimeSpan.FromDays(1));
+
     public Task<Guid> SaveAsync(CreateFeedRewindInfoDto create)
     {
         var id = Guid.NewGuid();
 
-        var info = new FeedRewindInfo
+        var feedRewind = new FeedRewindInfo
         {
             Id = id,
             FeedUrl = create.FeedUrl,
@@ -19,7 +24,8 @@ public class TestFeedRewindInfoRepository : IFeedRewindInfoRepository
             Interval = create.Interval,
         };
 
-        Data.FeedRewindInfoData.Add(info);
+        Data.FeedRewindInfoData.Add(feedRewind);
+        cache.Set(id, feedRewind, CacheEntryOptions);
 
         return Task.FromResult(id);
     }
@@ -29,7 +35,7 @@ public class TestFeedRewindInfoRepository : IFeedRewindInfoRepository
         var original = await GetAsync(edit.Id);
         if (original is null) throw new ArgumentException($"Item {edit.Id} does not exist.", nameof(edit));
 
-        var info = new FeedRewindInfo
+        var feedRewind = new FeedRewindInfo
         {
             Id = edit.Id,
             FeedUrl = edit.FeedUrl,
@@ -40,9 +46,15 @@ public class TestFeedRewindInfoRepository : IFeedRewindInfoRepository
         };
 
         Data.FeedRewindInfoData.Remove(original);
-        Data.FeedRewindInfoData.Add(info);
+        Data.FeedRewindInfoData.Add(feedRewind);
+        cache.Set(edit.Id, feedRewind, CacheEntryOptions);
     }
 
-    public Task<FeedRewindInfo?> GetAsync(Guid id) =>
-        Task.FromResult(Data.FeedRewindInfoData.SingleOrDefault(info => info.Id == id));
+    public async Task<FeedRewindInfo?> GetAsync(Guid id)
+    {
+        if (cache.TryGetValue(id, out FeedRewindInfo? feedRewind)) return feedRewind;
+        feedRewind = Data.FeedRewindInfoData.SingleOrDefault(info => info.Id == id);
+        if (feedRewind != null) cache.Set(id, feedRewind, CacheEntryOptions);
+        return feedRewind;
+    }
 }

--- a/PodcastRewind/TestData/TestSyndicationFeedService.cs
+++ b/PodcastRewind/TestData/TestSyndicationFeedService.cs
@@ -1,16 +1,28 @@
 using System.ServiceModel.Syndication;
 using System.Xml;
+using Microsoft.Extensions.Caching.Memory;
 using PodcastRewind.Services;
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 namespace PodcastRewind.TestData;
 
-public class TestSyndicationFeedService : ISyndicationFeedService
+public class TestSyndicationFeedService(IMemoryCache cache) : ISyndicationFeedService
 {
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetAbsoluteExpiration(TimeSpan.FromHours(20));
+
     public async Task<SyndicationFeed?> GetSyndicationFeedAsync(string url)
     {
         if (!Uri.IsWellFormedUriString(url, UriKind.Absolute)) return null;
+        if (cache.TryGetValue(url, out SyndicationFeed? feed)) return feed;
+        feed = await GetRemoteSyndicationFeedAsync();
+        if (feed != null) cache.Set(url, feed, CacheEntryOptions);
+        return feed;
+    }
+
+    private static async Task<SyndicationFeed?> GetRemoteSyndicationFeedAsync()
+    {
         using var xmlReader = XmlReader.Create(new StringReader(Data.SamplePodcastFeed));
         return SyndicationFeed.Load(xmlReader);
     }


### PR DESCRIPTION
When rewinding and updating feed items, clone the original feed first and work with the new feed item list. Otherwise, changes to the original feed items get persisted in the cache.